### PR TITLE
FIXED: changed Rigidbody2d to Dynamic

### DIFF
--- a/Assets/Prefabs/Arrow Projectile.prefab
+++ b/Assets/Prefabs/Arrow Projectile.prefab
@@ -72,7 +72,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damage: 50
-  speed: 10
+  speed: 12
 --- !u!1 &9058474361022539174
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ice-Waddle.prefab
+++ b/Assets/Prefabs/Ice-Waddle.prefab
@@ -74,7 +74,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2563334592570846981}
-  m_BodyType: 1
+  m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/Assets/Prefabs/Ice-Waddle.prefab
+++ b/Assets/Prefabs/Ice-Waddle.prefab
@@ -102,7 +102,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.75
 --- !u!1 &2563334593020081043
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -13,6 +13,8 @@ public class Projectile : MonoBehaviour
         transform.position += transform.up * speed * Time.deltaTime;
     }
 
+    // This callback is only triggered if one of the colliders also
+    // has a Rigidbody2d, set to Dynamic mode (not Kinematic)
     private void OnCollisionEnter2D(Collision2D other) {
         Debug.Log("WE HIT SOMETHING");
         // We only want to do damage to enemies.


### PR DESCRIPTION
Found this SO question that kind of explains why: https://gamedev.stackexchange.com/questions/154901/dynamic-vs-kinematic-do-either-of-these-cause-a-collision-before-oncollisionent

> ...only dynamic objects will automatically react by bouncing away, and cause OnCollisionEnter messages to be sent.