### PR TITLE
remove Circle Collider 2D property from heroes

### DIFF
--- a/Assets/Scenes/TestLevel.unity
+++ b/Assets/Scenes/TestLevel.unity
@@ -1907,6 +1907,11 @@ PrefabInstance:
       propertyPath: m_Radius
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 7300686530818841133, guid: bfd80d6817ac75e44be459816fc6b49b,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7300686530818841134, guid: bfd80d6817ac75e44be459816fc6b49b,
         type: 3}
       propertyPath: m_Sprite
@@ -4093,6 +4098,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Radius
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7300686530818841133, guid: bfd80d6817ac75e44be459816fc6b49b,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7300686530818841134, guid: bfd80d6817ac75e44be459816fc6b49b,
         type: 3}


### PR DESCRIPTION
So that heroes can't block waddles in path